### PR TITLE
overridden the attributeChangedCallback to handle initAttribute changes correctly

### DIFF
--- a/web-module/src/main/webapp/resources/celJS/BlogViewer.mjs
+++ b/web-module/src/main/webapp/resources/celJS/BlogViewer.mjs
@@ -1,11 +1,11 @@
-import pick from '/file/resource/deps/lodash/pick.js';
-import uniq from '/file/resource/deps/lodash/uniq.js';
+import pick from "/file/resource/deps/lodash/pick.js";
+import uniq from "/file/resource/deps/lodash/uniq.js";
 import {
   CelDataViewerElement,
-  Config
-} from '/file/resources/celDynJS/celData/cel-data-viewer.mjs?version=20250901';
+  Config,
+} from "/file/resources/celDynJS/celData/cel-data-viewer.mjs?version=20250901";
 
-const tagName = 'blog-viewer';
+const tagName = "blog-viewer";
 
 export class BlogFilter {
   searchTerm;
@@ -13,8 +13,8 @@ export class BlogFilter {
 }
 
 export class BlogParams extends BlogFilter {
-  xpage = 'celements_ajax';
-  ajax_mode = 'BlogViewJson';
+  xpage = "celements_ajax";
+  ajax_mode = "BlogViewJson";
   ajax = 1;
   showFields = [];
   start;
@@ -33,7 +33,7 @@ class BlogConfig extends Config {
     params.start = params.offset;
     params.nb = params.limit;
     params.showFields = uniq([
-      'searchInfo', // needed for hitCount
+      "searchInfo", // needed for hitCount
       ...params.showFields,
       ...params.fields,
     ]);
@@ -54,7 +54,6 @@ class BlogConfig extends Config {
 }
 
 class BlogViewerElement extends CelDataViewerElement {
-
   #mutationObserver;
 
   constructor() {
@@ -62,7 +61,7 @@ class BlogViewerElement extends CelDataViewerElement {
   }
 
   get method() {
-    return super.method ?? 'POST';
+    return super.method ?? "POST";
   }
 
   get path() {
@@ -70,33 +69,35 @@ class BlogViewerElement extends CelDataViewerElement {
   }
 
   get #path() {
-    if (!this.blog) throw new Error('attribute blog missing');
-    return `/${this.blog.split('.').join('/')}`;
+    if (!this.blog) throw new Error("attribute blog missing");
+    return `/${this.blog.split(".").join("/")}`;
   }
 
   get blog() {
-    return this.getAttribute('blog') || undefined;
+    return this.getAttribute("blog") || undefined;
   }
 
   set blog(value) {
-    this.setAttribute('blog', value);
+    this.setAttribute("blog", value);
   }
 
   get viewer() {
-  return this.loader;
+    return this.loader;
   }
 
   get sortFields() {
-    return (this.getAttribute('sort-fields') ?? "").split(',').filter(Boolean);
+    return (this.getAttribute("sort-fields") ?? "").split(",").filter(Boolean);
   }
 
   get params() {
-    return Object.assign(super.params, this.filter, { sortFields: this.sortFields });
+    return Object.assign(super.params, this.filter, {
+      sortFields: this.sortFields,
+    });
   }
 
   get filter() {
     const ret = new BlogFilter();
-    const json = this.getAttribute('filter') || '{}';
+    const json = this.getAttribute("filter") || "{}";
     try {
       Object.assign(ret, JSON.parse(json));
     } catch (error) {
@@ -109,7 +110,7 @@ class BlogViewerElement extends CelDataViewerElement {
     const filter = new BlogFilter();
     const params = this.config.createParams(value) ?? value;
     Object.assign(filter, pick(params, Object.keys(filter)));
-    this.setAttribute('filter', JSON.stringify(filter));
+    this.setAttribute("filter", JSON.stringify(filter));
   }
 
   setFilter(key, value) {
@@ -124,35 +125,43 @@ class BlogViewerElement extends CelDataViewerElement {
 
   #initBlogRenderer() {
     this.renderer.withPreInsert((entry, data) => {
-      entry.id = 'Art' + this.blog + ':' + data.articleId;
-      entry.classList.add('cel_cm_blog_article');
-      if (!data.isPublic) entry.classList.add('cel_nav_restricted_rights');
+      entry.id = "Art" + this.blog + ":" + data.articleId;
+      entry.classList.add("cel_cm_blog_article");
+      if (!data.isPublic) entry.classList.add("cel_nav_restricted_rights");
     });
   }
 
   #initContextMenuObserver() {
     this.#mutationObserver?.disconnect();
-    this.#mutationObserver = new MutationObserver((mutations) => 
-      mutations.some(m => m.type === "childList" && m.addedNodes.length > 0) 
-      && window.initContextMenuAsync?.()
+    this.#mutationObserver = new MutationObserver(
+      (mutations) =>
+        mutations.some(
+          (m) => m.type === "childList" && m.addedNodes.length > 0,
+        ) && window.initContextMenuAsync?.(),
     );
-    this.#mutationObserver.observe(this.renderer.htmlElem, {subtree: true, childList: true});
+    this.#mutationObserver.observe(this.renderer.htmlElem, {
+      subtree: true,
+      childList: true,
+    });
   }
 
   static get initAttributes() {
-    return uniq([...super.initAttributes, 'blog']);
+    return uniq([...super.initAttributes, "blog"]);
   }
 
   static get observedAttributes() {
-    return uniq([...super.observedAttributes, 'filter', 'sort-fields']);
+    return uniq([...super.observedAttributes, "filter", "sort-fields"]);
   }
 
   attributeChangedCallback(name, oldValue, newValue) {
     super.attributeChangedCallback?.(name, oldValue, newValue);
-    if (this.isConnected && this.loader && (oldValue !== newValue)) {
-      if (this.constructor.initAttributes.includes(name)) {
-        this.#initBlogRenderer();
-      }
+    if (
+      this.isConnected &&
+      this.loader &&
+      oldValue !== newValue &&
+      this.constructor.initAttributes.includes(name)
+    ) {
+      this.#initBlogRenderer();
     }
   }
 

--- a/web-module/src/main/webapp/resources/celJS/BlogViewer.mjs
+++ b/web-module/src/main/webapp/resources/celJS/BlogViewer.mjs
@@ -119,6 +119,7 @@ class BlogViewerElement extends CelDataViewerElement {
   connectedCallback() {
     super.connectedCallback();
     this.#initBlogRenderer();
+    this.#initContextMenuObserver();
   }
 
   #initBlogRenderer() {
@@ -127,6 +128,10 @@ class BlogViewerElement extends CelDataViewerElement {
       entry.classList.add('cel_cm_blog_article');
       if (!data.isPublic) entry.classList.add('cel_nav_restricted_rights');
     });
+  }
+
+  #initContextMenuObserver() {
+    this.#mutationObserver?.disconnect();
     this.#mutationObserver = new MutationObserver((mutations) => 
       mutations.some(m => m.type === "childList" && m.addedNodes.length > 0) 
       && window.initContextMenuAsync?.()
@@ -140,6 +145,17 @@ class BlogViewerElement extends CelDataViewerElement {
 
   static get observedAttributes() {
     return uniq([...super.observedAttributes, 'filter', 'sort-fields']);
+  }
+
+  attributeChangedCallback(name, oldValue, newValue) {
+    if (super.attributeChangedCallback) {
+      super.attributeChangedCallback(name, oldValue, newValue);
+    }
+    if (this.isConnected && this.loader && (oldValue !== newValue)) {
+      if (this.constructor.initAttributes.includes(name)) {
+        this.#initBlogRenderer();
+      }
+    }
   }
 
   disconnectedCallback() {

--- a/web-module/src/main/webapp/resources/celJS/BlogViewer.mjs
+++ b/web-module/src/main/webapp/resources/celJS/BlogViewer.mjs
@@ -148,9 +148,7 @@ class BlogViewerElement extends CelDataViewerElement {
   }
 
   attributeChangedCallback(name, oldValue, newValue) {
-    if (super.attributeChangedCallback) {
-      super.attributeChangedCallback(name, oldValue, newValue);
-    }
+    super.attributeChangedCallback?.(name, oldValue, newValue);
     if (this.isConnected && this.loader && (oldValue !== newValue)) {
       if (this.constructor.initAttributes.includes(name)) {
         this.#initBlogRenderer();


### PR DESCRIPTION
### Issue
When any variable inside `initAttributes` changes, `this.#init()` is called, it creates a completely new instance of `CelDataRenderer`. Because `BlogViewerElement` initially attached `withPreInsert` inside `connectedCallback`, which only fires once when the element is attached to the DOM, the newly created renderer object loses the `withPreInsert` hook! That's why the new results lack the `cel_cm_blog_article` classes and context menus.

### Fix
I've overridden the `attributeChangedCallback` so that `BlogViewerElement` listens to attribute changes, allows the superclass to do its job (which includes creating the new renderer if needed), and then correctly re-applies `#initBlogRenderer()` when an `initAttribute` is changed.