### PR TITLE
Move XML templates and context menus to correct web-module subprojects

### DIFF
--- a/web-module/src/main/webapp/docs/celements2web/BlogTemplates/ArticleClassTemplate.xml
+++ b/web-module/src/main/webapp/docs/celements2web/BlogTemplates/ArticleClassTemplate.xml
@@ -80,7 +80,7 @@
 <number>9</number>
 <picker>1</picker>
 <prettyName>archivedate</prettyName>
-<size>20</size>
+<size>0</size>
 <unmodifiable>0</unmodifiable>
 <validationMessage>cel_blog_validation_archivedate</validationMessage>
 <validationRegExp>/(^$)|^((0[1-9]|[12][0-9]|3[01])\.(0[1-9]|1[012])\.([0-9]{4}) ([01][0-9]|2[0-4])(\:[0-5][0-9]))$/</validationRegExp>
@@ -162,7 +162,7 @@
 <number>7</number>
 <picker>1</picker>
 <prettyName>publishdate</prettyName>
-<size>20</size>
+<size>0</size>
 <unmodifiable>0</unmodifiable>
 <validationMessage>cel_blog_validation_publishdate</validationMessage>
 <validationRegExp>/^((0[1-9]|[12][0-9]|3[01])\.(0[1-9]|1[012])\.([0-9]{4}) ([01][0-9]|2[0-4])(\:[0-5][0-9]))$/</validationRegExp>

--- a/web-module/src/main/webapp/docs/celements2web/PageTypes/Article.xml
+++ b/web-module/src/main/webapp/docs/celements2web/PageTypes/Article.xml
@@ -3,7 +3,7 @@
 <web>PageTypes</web>
 <name>Article</name>
 <language></language>
-<defaultLanguage>en</defaultLanguage>
+<defaultLanguage></defaultLanguage>
 <translation>0</translation>
 <parent></parent>
 <creator>xwiki:XWiki.fpichler</creator>

--- a/web-module/src/main/webapp/docs/celements2web/PageTypes/Blog.xml
+++ b/web-module/src/main/webapp/docs/celements2web/PageTypes/Blog.xml
@@ -3,7 +3,7 @@
 <web>PageTypes</web>
 <name>Blog</name>
 <language></language>
-<defaultLanguage>en</defaultLanguage>
+<defaultLanguage></defaultLanguage>
 <translation>0</translation>
 <parent></parent>
 <creator></creator>


### PR DESCRIPTION
This change refactors the location of various XML templates, page types, and context menus. Files that were previously added or modified in the main `celements-web` repository but logically belong to other component repositories have been relocated to their correct web-module subprojects. 

Across all touched repositories, these changes have been committed and pushed under the branch:
`update-celements2web-7x-onDisk`
